### PR TITLE
Fix closing bracket in agent deployment template

### DIFF
--- a/openshift/templates/issuer-agent/issuer-agent-deploy.yaml
+++ b/openshift/templates/issuer-agent/issuer-agent-deploy.yaml
@@ -182,8 +182,8 @@ objects:
                   --admin '0.0.0.0' ${ADMIN_INTERFACE_PORT}
                   $([ ! -z "${AGENT_ADMIN_API_KEY}" ] && echo "--admin-api-key ${AGENT_ADMIN_API_KEY}" || echo "--admin-insecure-mode")
                   --label "${AGENT_NAME}"
-                  --log-level ${AGENT_LOG_LEVEL})
-                  --tails-server-base-url ${TAILS_SERVER_BASE_URL};
+                  --log-level ${AGENT_LOG_LEVEL}
+                  --tails-server-base-url ${TAILS_SERVER_BASE_URL});
               env:
                 - name: GENESIS_URL
                   value: ${GENESIS_FILE_URL}


### PR DESCRIPTION
No functional change in the updated deployment configuration - both work the same. However, it is more correct to keep everything inside the same `echo` statement if it needs to be used.

Relevant deployments have all been updated.

@WadeBarnes 