### PR TITLE
Update to CA-Py 0.6.0, miscellaneous tweaks

### DIFF
--- a/openshift/settings.a2a.sh
+++ b/openshift/settings.a2a.sh
@@ -1,4 +1,4 @@
 # Description: Credential issuer profile
 export SKIP_PIPELINE_PROCESSING=1
-export include_templates="issuer-agent-build issuer-agent-deploy issuer-api-build issuer-api-deploy issuer-db-build issuer-db-deploy issuer-web-base-build issuer-web-build issuer-web-deploy issuer-wallet-build issuer-wallet-deploy"
+export include_templates="issuer-agent-deploy issuer-api-deploy issuer-db-deploy issuer-web-deploy issuer-wallet-deploy"
 export ignore_templates=""

--- a/openshift/settings.lsbc.sh
+++ b/openshift/settings.lsbc.sh
@@ -1,4 +1,4 @@
 # Description: Law Society of BC profile
 export SKIP_PIPELINE_PROCESSING=1
-export include_templates="issuer-agent-build issuer-agent-deploy issuer-wallet-build issuer-wallet-deploy"
+export include_templates="issuer-agent-deploy issuer-wallet-deploy"
 export ignore_templates=""

--- a/openshift/settings.prime.sh
+++ b/openshift/settings.prime.sh
@@ -1,4 +1,4 @@
 # Description: Prime Health profile
 export SKIP_PIPELINE_PROCESSING=1
-export include_templates="issuer-agent-build issuer-agent-deploy issuer-wallet-build issuer-wallet-deploy visual-verifier-build visual-verifier-deploy"
+export include_templates="issuer-agent-deploy issuer-wallet-deploy visual-verifier-deploy"
 export ignore_templates=""

--- a/openshift/settings.sh
+++ b/openshift/settings.sh
@@ -3,6 +3,6 @@ export PROJECT_NAMESPACE="nnfbch"
 export GIT_URI="https://github.com/bcgov/a2a-trust-over-ip-configurations.git"
 export GIT_REF="master"
 
-export skip_git_overrides="agent-build.json controller-build.json database-build.json backup-build.json api-build.json db-build.json wallet-build.json issuer-web-base-build.json issuer-web-build.json tails-server-build.json visual-verifier-build.json"
+export skip_git_overrides="agent-build.json controller-build.json database-build.json backup-build.json api-build.json db-build.json issuer-agent-build.json wallet-build.json issuer-web-base-build.json issuer-web-build.json tails-server-build.json visual-verifier-build.json"
 
 export ignore_templates="issuer-agent-deploy issuer-api-deploy issuer-db-deploy issuer-web-deploy issuer-wallet-deploy tails-server-deploy visual-verifier-deploy"

--- a/openshift/settings.tails.sh
+++ b/openshift/settings.tails.sh
@@ -1,4 +1,4 @@
 # Description: Tails Server profile
 export SKIP_PIPELINE_PROCESSING=1
-export include_templates="tails-server-build tails-server-deploy"
+export include_templates="tails-server-deploy"
 export ignore_templates=""

--- a/openshift/templates/agent-rev/agent-rev-deploy.yaml
+++ b/openshift/templates/agent-rev/agent-rev-deploy.yaml
@@ -126,6 +126,7 @@ objects:
                   --auto-respond-messages
                   --auto-respond-credential-offer
                   --auto-verify-presentation
+                  --auto-provision
                   --wallet-type 'indy'
                   --wallet-name "$(echo ${AGENT_WALLET_NAME} | tr '[:upper:]' '[:lower:]' | sed "s~-~_~g")"
                   --wallet-key "${WALLET_ENCRYPTION_KEY}"

--- a/openshift/templates/agent/agent-deploy.yaml
+++ b/openshift/templates/agent/agent-deploy.yaml
@@ -126,6 +126,7 @@ objects:
                   --auto-respond-messages
                   --auto-respond-credential-offer
                   --auto-verify-presentation
+                  --auto-provision
                   --wallet-type 'indy'
                   --wallet-name "$(echo ${AGENT_WALLET_NAME} | tr '[:upper:]' '[:lower:]' | sed "s~-~_~g")"
                   --wallet-key "${WALLET_ENCRYPTION_KEY}"

--- a/openshift/templates/issuer-agent/issuer-agent-deploy.yaml
+++ b/openshift/templates/issuer-agent/issuer-agent-deploy.yaml
@@ -88,7 +88,7 @@ objects:
     spec:
       storageClassName: "${TAILS_FILES_VOLUME_CLASS}"
       accessModes:
-      - ReadWriteMany
+        - ReadWriteMany
       resources:
         requests:
           storage: "${TAILS_FILES_VOLUME_SIZE}"
@@ -172,6 +172,7 @@ objects:
                   --auto-respond-messages
                   --auto-respond-credential-offer
                   --auto-verify-presentation
+                  --auto-provision
                   --wallet-type 'indy'
                   --wallet-name "$(echo ${AGENT_WALLET_NAME} | tr '[:upper:]' '[:lower:]' | sed "s~-~_~g")"
                   --wallet-key "${WALLET_ENCRYPTION_KEY}"
@@ -259,16 +260,15 @@ objects:
                 - containerPort: ${{AGENT_HTTP_PORT}}
                   protocol: TCP
               volumeMounts:
-              - name: ${NAME}${SUFFIX}-tails
-                  mountPath: '${TAILS_FILES_DIR}'
-
+                - name: ${NAME}${SUFFIX}-tails
+                  mountPath: "${TAILS_FILES_DIR}"
               readinessProbe:
                 timeoutSeconds: 30
                 initialDelaySeconds: 3
                 exec:
                   command:
                     - bash
-                    - '-c'
+                    - "-c"
                     - 'curl --fail "http://localhost:${ADMIN_INTERFACE_PORT}/status/ready" -H "X-API-KEY: ${AGENT_ADMIN_API_KEY}"'
               livenessProbe:
                 timeoutSeconds: 30
@@ -276,7 +276,7 @@ objects:
                 exec:
                   command:
                     - bash
-                    - '-c'
+                    - "-c"
                     - 'curl --fail "http://localhost:${ADMIN_INTERFACE_PORT}/status/live" -H "X-API-KEY: ${AGENT_ADMIN_API_KEY}"'
 
               imagePullPolicy: IfNotPresent
@@ -521,14 +521,12 @@ parameters:
     value: /home/indy/.indy_client/tails
   - name: TAILS_FILES_VOLUME_CLASS
     displayName: Tails File Storage Volume Class
-    description:
-      The class of the volume; gluster-file, gluster-block, gluster-file-db, netapp-file-standard, netapp-block-standard.
+    description: The class of the volume; gluster-file, gluster-block, gluster-file-db, netapp-file-standard, netapp-block-standard.
     required: true
     value: netapp-file-standard
   - name: TAILS_FILES_VOLUME_SIZE
     displayName: Tails File Storage Dir
-    description:
-      The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
+    description: The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
     required: true
     value: 1Gi
   - name: TAILS_SERVER_BASE_URL

--- a/proof-configurations/prime-enrollee/test/prime-enrollee.json
+++ b/proof-configurations/prime-enrollee/test/prime-enrollee.json
@@ -1,21 +1,27 @@
 {
-    "id": "prime-enrollee-test",
-    "subject_identifier": "gpid",
-    "configuration": {
-      "name": "prime-enrollee",
-      "version": "0.0.2",
-      "requested_attributes": [
-        {
-          "names": ["gpid", "organization_type", "remote_access", "renewal_date", "user_class"],
-          "restrictions": [
-            {
-              "issuer_did": "TVmQfMZwLFWWK3z1RLgFBR",
-              "schema_name": "enrollee",
-              "schema_version": "2.0"
-            }
-          ]
-        }
-      ],
-      "requested_predicates": []
-    }
+  "id": "prime-enrollee-test",
+  "subject_identifier": "gpid",
+  "configuration": {
+    "name": "prime-enrollee",
+    "version": "0.0.3",
+    "requested_attributes": [
+      {
+        "names": [
+          "GPID",
+          "Renewal Date",
+          "Care Type Setting",
+          "TOA Name",
+          "Remote User"
+        ],
+        "restrictions": [
+          {
+            "issuer_did": "TVmQfMZwLFWWK3z1RLgFBR",
+            "schema_name": "enrollee",
+            "schema_version": "2.2"
+          }
+        ]
+      }
+    ],
+    "requested_predicates": []
   }
+}


### PR DESCRIPTION
The miscellaneous tweaks include:
- updating the `prime-enrollee` proof-request configuration (already deployed)
- reorganizing the profiles

The templates have been updated to use ACA-Py 0.6.0, however only the deployments in `dev` have been upgraded in order to allow end-users to check they are not incurring in any breaking changes before we push the updates further.
The deployment changes affect both the issuer agents and the `vc-authn` agents.