### PR TITLE
New credential challenge for separate KC client. 

### DIFF
--- a/proof-configurations/bpa-sandbox-access/test/bpa-sandbox-access.json
+++ b/proof-configurations/bpa-sandbox-access/test/bpa-sandbox-access.json
@@ -1,0 +1,23 @@
+{
+    "id": "bpa-sandbox-access-test",
+    "subject_identifier": "",
+    "configuration": {
+      "name": "bpa-sandbox-access",
+      "version": "0.1",
+      "requested_attributes": [
+        {
+          "names": [
+            "business_role"
+          ],
+          "restrictions": [
+            {
+              "issuer_did": "7o2YVzymVZEm6DUiLYa1hc",
+              "schema_name": "bpa-sandbox-access",
+              "schema_version": "0.1"
+            }
+          ]
+        }
+      ],
+      "requested_predicates": []
+    }
+  }


### PR DESCRIPTION
This is being separated because do not want to provide IDIR login and this instances will be accessible by non-gov members. We want to provide a KC username/password login, and a VC login.
