### PR TITLE
fix: Memory and allocator adjustments

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -65,11 +65,7 @@ environment:
   - name: PUSH_NOTIFICATION_BODY
     value: "Please open your wallet"
   - name: NODE_OPTIONS
-    value: "--max-old-space-size=120"
-  - name: MALLOC_CONF
-    value: "background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000"
-  - name: LD_PRELOAD
-    value: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+    value: "--max-old-space-size=128"
   - name: POSTGRES_HOST
     value: aries-mediator-db
   - name: POSTGRES_USER

--- a/services/mediator-credo/charts/prod/values.yaml
+++ b/services/mediator-credo/charts/prod/values.yaml
@@ -37,7 +37,7 @@ resources:
     memory: 2Gi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 environment:
   - name: LOG_LEVEL
@@ -65,7 +65,7 @@ environment:
   - name: PUSH_NOTIFICATION_BODY
     value: "Please open your wallet"
   - name: NODE_OPTIONS
-    value: "--max-old-space-size=120"
+    value: "--max-old-space-size=256"
   - name: MALLOC_CONF
     value: "background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000"
   - name: LD_PRELOAD

--- a/services/mediator-credo/charts/test/values.yaml
+++ b/services/mediator-credo/charts/test/values.yaml
@@ -37,7 +37,7 @@ resources:
     memory: 2Gi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 environment:
   - name: LOG_LEVEL
@@ -65,7 +65,7 @@ environment:
   - name: PUSH_NOTIFICATION_BODY
     value: "Please open your wallet"
   - name: NODE_OPTIONS
-    value: "--max-old-space-size=120"
+    value: "--max-old-space-size=256"
   - name: MALLOC_CONF
     value: "background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000"
   - name: LD_PRELOAD


### PR DESCRIPTION
I think these settings are better for memory and the jemalloc allocator.

You can't really use jemalloc with a 256 mb pod. It reserves memory immediately and the node and other memory reserves enough that the pod will immediately fail.

I've removed jemalloc from the dev instance as this won't be load tested against and mostly idle. For prod and test I increased the pod memory to 512 mb. 

After we're done load testing on test we could revert this. Or we can revert it now and only enable when we are ready to load test. I think the jemalloc allocator is going to be important under load.

I could lower the max replicas to 3 or 4 if we want to restrain the memory usage to basically what it had before. I don't think 6 will be necessary expect maybe under very heavy load.