### PR TITLE
feat: Only scale on CPU

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -91,7 +91,6 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
-  targetMemoryUtilizationPercentage: 80
 
 postgresql:
   enabled: true

--- a/services/mediator-credo/charts/prod/values.yaml
+++ b/services/mediator-credo/charts/prod/values.yaml
@@ -95,7 +95,6 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
-  targetMemoryUtilizationPercentage: 80
 
 postgresql:
   enabled: true

--- a/services/mediator-credo/charts/test/values.yaml
+++ b/services/mediator-credo/charts/test/values.yaml
@@ -95,7 +95,6 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
-  targetMemoryUtilizationPercentage: 80
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Changes the scaling to only occur on CPU which is a better indicator of load.

Memory stays relatively flat when using the jemalloc allocator and will keep memory cached for crypto operations so it doesn't return memory to previous levels very quickly if at all.

We may need to adjust memory limits up after more substantial load testing but an upper limit of 2 GB has looked good for now.