### PR TITLE
Update Redis image repositories to use legacy repository

### DIFF
--- a/services/redis/charts/redis-cluster/values.yaml
+++ b/services/redis/charts/redis-cluster/values.yaml
@@ -26,7 +26,7 @@ redis:
     ## Security parameters
     ##
     security:
-      ## @param global.security.allowInsecureImages Allows skipping image verification
+      ## @param global.security.allowInsecureImages This does not do any actual security validation. This is just a flag to allow the substitution of images which were not originally set by the chart defaults.
       allowInsecureImages: true
     redis:
       password: ""

--- a/services/redis/charts/redis/values.yaml
+++ b/services/redis/charts/redis/values.yaml
@@ -26,7 +26,7 @@ redis:
     ## Security parameters
     ##
     security:
-      ## @param global.security.allowInsecureImages Allows skipping image verification
+      ## @param global.security.allowInsecureImages This does not do any actual security validation. This is just a flag to allow the substitution of images which were not originally set by the chart defaults.
       allowInsecureImages: true
     redis:
       password: ""


### PR DESCRIPTION
Setting `global.security.allowInsecureImages=true` is required by the Bitnami helm charts to update to use `bitnamilegacy` repository.