### PR TITLE
chore: update vc-authn-oidc chart version to 0.5.1 and enable redis

### DIFF
--- a/services/vc-authn-oidc/charts/dev/Chart.yaml
+++ b/services/vc-authn-oidc/charts/dev/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: vc-authn-oidc
 description: vc-authn-oidc - dev
 type: application
-version: 0.4.5
+version: 0.5.1
 appVersion: "2.3.5"
 dependencies:
   - name: vc-authn-oidc
-    version: 0.4.5
+    version: 0.5.1
     repository: https://openwallet-foundation.github.io/helm-charts/

--- a/services/vc-authn-oidc/charts/dev/values.yaml
+++ b/services/vc-authn-oidc/charts/dev/values.yaml
@@ -130,3 +130,5 @@ vc-authn-oidc:
     livenessProbe:
       enabled: true
       timeoutSeconds: 10
+  redis:
+    enabled: true


### PR DESCRIPTION
update to chart version 0.5.1, keeping the image tag at version 2.3.5 