### PR TITLE
chore: Update chart version to 0.6.0

### DIFF
--- a/services/mediator-credo/charts/dev/Chart.yaml
+++ b/services/mediator-credo/charts/dev/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: didcomm-mediator-credo
 description: didcomm-mediator-credo - dev
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.1.0"
 dependencies:
   - name: didcomm-mediator-credo
-    version: 0.5.0
+    version: 0.6.0
     repository: https://openwallet-foundation.github.io/helm-charts

--- a/services/mediator-credo/charts/prod/Chart.yaml
+++ b/services/mediator-credo/charts/prod/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: didcomm-mediator-credo
 description: didcomm-mediator-credo - prod
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.1.0"
 dependencies:
   - name: didcomm-mediator-credo
-    version: 0.5.0
+    version: 0.6.0
     repository: https://openwallet-foundation.github.io/helm-charts

--- a/services/mediator-credo/charts/test/Chart.yaml
+++ b/services/mediator-credo/charts/test/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: didcomm-mediator-credo
 description: didcomm-mediator-credo - test
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.1.0"
 dependencies:
   - name: didcomm-mediator-credo
-    version: 0.5.0
+    version: 0.6.0
     repository: https://openwallet-foundation.github.io/helm-charts


### PR DESCRIPTION
Hopefully this is actually the latest upgrade for a while. This point to the latest image with the pickup database migration fix.