### PR TITLE
Update webvh chart location

### DIFF
--- a/services/didwebvh-server-py/charts/dev/Chart.yaml
+++ b/services/didwebvh-server-py/charts/dev/Chart.yaml
@@ -7,4 +7,4 @@ appVersion: "0.5.0"
 dependencies:
   - name: didwebvh-server-py
     version: 0.5.0
-    repository: https://github.com/decentralized-identity/didwebvh-server-py/tree/gh-pages
+    repository: https://raw.githubusercontent.com/decentralized-identity/didwebvh-server-py/refs/heads/gh-pages


### PR DESCRIPTION
The WebVH Server repo now has a user manual served on gh pages. This deployment conflicts with the hosted charts. I suggest to move the chart to an aggregated repository (such as helm-charts), similar to how charts are managed at the open wallet foundation.

In the meantime, we can update the chart URL to use the github repository directly.