### PR TITLE
Update GOAL_CODE value in values.yaml files for Mediator

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -58,7 +58,7 @@ didcomm-mediator-credo:
     - name: CREATE_NEW_INVITATION
       value: "false"
     - name: GOAL_CODE
-      value: "vc.mediate"
+      value: "aries.vc.mediate"
     - name: USE_PUSH_NOTIFICATIONS
       value: "true"
     - name: PUSH_NOTIFICATION_TITLE

--- a/services/mediator-credo/charts/prod/values.yaml
+++ b/services/mediator-credo/charts/prod/values.yaml
@@ -58,7 +58,7 @@ didcomm-mediator-credo:
     - name: CREATE_NEW_INVITATION
       value: "false"
     - name: GOAL_CODE
-      value: "vc.mediate"
+      value: "aries.vc.mediate"
     - name: USE_PUSH_NOTIFICATIONS
       value: "true"
     - name: PUSH_NOTIFICATION_TITLE

--- a/services/mediator-credo/charts/test/values.yaml
+++ b/services/mediator-credo/charts/test/values.yaml
@@ -58,7 +58,7 @@ didcomm-mediator-credo:
     - name: CREATE_NEW_INVITATION
       value: "false"
     - name: GOAL_CODE
-      value: "vc.mediate"
+      value: "aries.vc.mediate"
     - name: USE_PUSH_NOTIFICATIONS
       value: "true"
     - name: PUSH_NOTIFICATION_TITLE


### PR DESCRIPTION
Changed the GOAL_CODE environment variable from "vc.mediate" to "aries.vc.mediate" in the dev, prod, and test values.yaml files for didcomm-mediator-credo.