### PR TITLE
chore: Enable websocket/http session affinity in mediator router

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -6,7 +6,7 @@ didcomm-mediator-credo:
       route.openshift.io/termination: edge
       haproxy.router.openshift.io/disable_cookies: "false"
       haproxy.router.openshift.io/cookie_name: ROUTEID
-      haproxy.router.openshift.io/timeout: 1h
+      haproxy.router.openshift.io/timeout: "3600s"
     labels:
       certbot-managed: "true"
     hosts:


### PR DESCRIPTION
Trying to get sticky sessions working for the mediator for improved performance. Trying with only the dev namespace first. I'm unsure if it will work.