### PR TITLE
chore: Disable sticky sessions by cookies for dev mediator

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -4,9 +4,8 @@ didcomm-mediator-credo:
     className: ""
     annotations:
       route.openshift.io/termination: edge
-      haproxy.router.openshift.io/disable_cookies: "false"
-      haproxy.router.openshift.io/cookie_name: ROUTEID
-      haproxy.router.openshift.io/timeout: "3600s"
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
     labels:
       certbot-managed: "true"
     hosts:


### PR DESCRIPTION
This was the wrong approach as it requires client side implementation. I found a different way to do this with sessionAffinity at the service layer that doesn't require client side action.

Reverting to the original defaults.