### PR TITLE
chore: Update log level and min replicas

### DIFF
--- a/services/mediator-credo/charts/dev/values.yaml
+++ b/services/mediator-credo/charts/dev/values.yaml
@@ -42,7 +42,7 @@ didcomm-mediator-credo:
 
   environment:
     - name: LOG_LEVEL
-      value: "2"
+      value: "3"
     - name: AGENT_PORT
       value: "3000"
     - name: AGENT_NAME
@@ -89,7 +89,7 @@ didcomm-mediator-credo:
 
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 6
     targetCPUUtilizationPercentage: 80
 

--- a/services/mediator-credo/charts/prod/values.yaml
+++ b/services/mediator-credo/charts/prod/values.yaml
@@ -42,7 +42,7 @@ didcomm-mediator-credo:
 
   environment:
     - name: LOG_LEVEL
-      value: "2"
+      value: "3"
     - name: AGENT_PORT
       value: "3000"
     - name: AGENT_NAME
@@ -99,7 +99,7 @@ didcomm-mediator-credo:
 
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 6
     targetCPUUtilizationPercentage: 80
 

--- a/services/mediator-credo/charts/test/values.yaml
+++ b/services/mediator-credo/charts/test/values.yaml
@@ -42,7 +42,7 @@ didcomm-mediator-credo:
 
   environment:
     - name: LOG_LEVEL
-      value: "2"
+      value: "3"
     - name: AGENT_PORT
       value: "3000"
     - name: AGENT_NAME
@@ -93,7 +93,7 @@ didcomm-mediator-credo:
 
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 6
     targetCPUUtilizationPercentage: 80
 


### PR DESCRIPTION
These have been deployed manually to all namespaces. The min replicas is to have extra assurance in scaling scenarios and the debug level is excessive with a stable system.