### PR TITLE
chore(webvh): update DIF chart and values for sandbox, dev, test, prod

### DIFF
--- a/services/didwebvh-server-py/charts/dev/Chart.yaml
+++ b/services/didwebvh-server-py/charts/dev/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.5.0
 appVersion: "0.5.0"
 dependencies:
   - name: didwebvh-server-py
-    version: 0.5.0
-    repository: https://raw.githubusercontent.com/decentralized-identity/didwebvh-server-py/refs/heads/gh-pages
+    version: 0.7.0
+    repository: https://decentralized-identity.github.io/helm-charts

--- a/services/didwebvh-server-py/charts/dev/values.yaml
+++ b/services/didwebvh-server-py/charts/dev/values.yaml
@@ -1,72 +1,78 @@
 ---
-didwebvh-server-py:
+# Top-level keys so the DIF chart receives them (chart uses .Values.ingress, .Values.server, etc.)
+ingress:
+  annotations:
+    route.openshift.io/termination: edge
+  tls:
+    - secretName: webvh-server-tls
+      hosts:
+        - registry-dev.digitaltrust.gov.bc.ca
+networkPolicy:
   ingress:
-    annotations:
-      route.openshift.io/termination: edge
-    tls:
-      - secretName: webvh-server-tls
-        hosts:
-          - registry-dev.digitaltrust.gov.bc.ca
+    namespaceSelector:
+      network.openshift.io/policy-group: ingress
+
+server:
+  image:
+    repository: ghcr.io/decentralized-identity/didwebvh-server-py
+    tag: 0.5.0
+    pullPolicy: Always
+  host: "registry-dev.digitaltrust.gov.bc.ca"
+  workers: "4"
+  policies:
+    webvh_version: "1.0"
+    webvh_witness: "true"
+    webvh_watcher: ""
+    webvh_prerotation: "true"
+    webvh_portability: "true"
+    webvh_endorsement: "true"
+    webvh_known_witness_key: "z6MkjV3rqLT8viLNYqhHSiqSW2DcTrbCL4L53YDyV6wcmGC5"
+    webvh_known_registry_url: ""
+
+  branding:
+    app_name: "BCVH (Dev)"
+    app_description: "BC Gov WebVH server (Development)."
+    icon: "https://www2.gov.bc.ca/favicon.ico"
+    logo_vertical : "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    logo_horizontal  : "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    app_primary_color: "#234075"
+    app_secondary_color: "#e3a82b"
+    app_accent_color: "#82B1FF"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
   networkPolicy:
+    enabled: true
     ingress:
+      enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
-  server:
-    image:
-      repository: ghcr.io/decentralized-identity/didwebvh-server-py
-      tag: 0.5.0
-      pullPolicy: Always
-    host: "registry-dev.digitaltrust.gov.bc.ca"
-    workers: "4"
-    policies:
-      webvh_version: "1.0"
-      webvh_witness: "true"
-      webvh_watcher: ""
-      webvh_prerotation: "true"
-      webvh_portability: "true"
-      webvh_endorsement: "true"
-      webvh_known_witness_key: "z6MkjV3rqLT8viLNYqhHSiqSW2DcTrbCL4L53YDyV6wcmGC5"
-      webvh_known_registry_url: ""
 
-    branding:
-      app_name: "BCVH (Dev)"
-      app_description: "BC Gov WebVH server (Development)."
-      icon: "https://www2.gov.bc.ca/favicon.ico"
-      logo_vertical : "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
-      logo_horizontal  : "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
-      app_primary_color: "#234075"
-      app_secondary_color: "#e3a82b"
-      app_accent_color: "#82B1FF"
+# (Postgres config is at top level below so the DIF chart sees .Values.postgres)
 
-    autoscaling:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
-      stabilizationWindowSeconds: 300
-    resources:
-      limits:
-        cpu: 250m
-        memory: 512Mi
-      requests:
-        cpu: 50m
-        memory: 128Mi
-    networkPolicy:
-      enabled: true
-      ingress:
-        enabled: true
-        namespaceSelector:
-          network.openshift.io/policy-group: ingress
-
-  postgresql:
-    image:
-      registry: artifacts.developer.gov.bc.ca
-      repository: docker-remote/bitnamilegacy/postgresql
-      tag: 14.5.0-debian-11-r35
-    commonLabels:
-      backup: "true"
-      env: dev
-    primary:
-      persistence:
-        size: 5Gi
+# New chart (0.7.0) uses CloudPirates postgres subchart; see MIGRATION_PLAN.md.
+# Must be top-level so the chart passes it to the subchart and creates this DB.
+postgres:
+  enabled: true
+  commonLabels:
+    backup: "true"
+    env: dev
+  persistence:
+    enabled: true
+    # 3Gi to stay under namespace storage-quota (64Gi); increase if quota is raised
+    size: 3Gi
+  customUser:
+    name: "webvh-admin"
+    database: "didwebvh-server"

--- a/services/didwebvh-server-py/charts/prod/Chart.yaml
+++ b/services/didwebvh-server-py/charts/prod/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.4.5
 appVersion: "0.4.5"
 dependencies:
   - name: didwebvh-server-py
-    version: 0.4.5
-    repository: https://identity.foundation/didwebvh-server-py
+    version: 0.7.0
+    repository: https://decentralized-identity.github.io/helm-charts

--- a/services/didwebvh-server-py/charts/prod/values.yaml
+++ b/services/didwebvh-server-py/charts/prod/values.yaml
@@ -1,71 +1,74 @@
 ---
-didwebvh-server-py:
+# Top-level keys so the DIF chart receives them (chart uses .Values.ingress, .Values.server, etc.)
+ingress:
+  annotations:
+    route.openshift.io/termination: edge
+  tls:
+    - secretName: webvh-server-tls
+      hosts:
+        - registry.digitaltrust.gov.bc.ca
+networkPolicy:
   ingress:
-    annotations:
-      route.openshift.io/termination: edge
-    tls:
-      - secretName: webvh-server-tls
-        hosts:
-          - registry.digitaltrust.gov.bc.ca
+    namespaceSelector:
+      network.openshift.io/policy-group: ingress
+
+server:
+  image:
+    repository: ghcr.io/decentralized-identity/didwebvh-server-py
+    tag: 0.5.0
+    pullPolicy: Always
+  host: "registry.digitaltrust.gov.bc.ca"
+  workers: "4"
+  policies:
+    webvh_version: "1.0"
+    webvh_witness: "true"
+    webvh_watcher: ""
+    webvh_prerotation: "false"
+    webvh_portability: "false"
+    webvh_endorsement: "true"
+    webvh_known_witness_key: ""
+    webvh_known_registry_url: ""
+
+  branding:
+    app_name: "BC Gov WebVH Prod"
+    app_description: "BC Gov Prod WebVH server deployment."
+    icon: "https://www2.gov.bc.ca/favicon.ico"
+    logo_vertical: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    logo_horizontal: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    app_primary_color: "#234075"
+    app_secondary_color: "#e3a82b"
+    app_accent_color: "#82B1FF"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
   networkPolicy:
+    enabled: true
     ingress:
+      enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
 
-  server:
-    image:
-      repository: ghcr.io/decentralized-identity/didwebvh-server-py
-      tag: 0.4.5
-      pullPolicy: Always
-    host: "registry.digitaltrust.gov.bc.ca"
-    workers: "4"
-    policies:
-      webvh_version: "1.0"
-      webvh_witness: "true"
-      webvh_watcher: ""
-      webvh_prerotation: "false"
-      webvh_portability: "false"
-      webvh_endorsement: "true"
-      webvh_known_witness_key: ""
-      webvh_known_registry_url: ""
-
-    branding:
-      app_name: "BC Gov WebVH Prod"
-      app_description: "BC Gov Prod WebVH server deployment."
-      app_icon: "https://www2.gov.bc.ca/favicon.ico"
-      app_logo: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
-      app_primary_color: "#234075"
-      app_secondary_color: "#e3a82b"
-      app_accent_color: "#82B1FF"
-      
-    autoscaling:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 6
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
-      stabilizationWindowSeconds: 300
-    resources:
-      limits:
-        cpu: 250m
-        memory: 512Mi
-      requests:
-        cpu: 50m
-        memory: 128Mi
-    networkPolicy:
-      enabled: true
-      ingress:
-        enabled: true
-        namespaceSelector:
-          network.openshift.io/policy-group: ingress
-  postgresql:
-    image:
-      registry: artifacts.developer.gov.bc.ca
-      repository: docker-remote/bitnamilegacy/postgresql
-      tag: 14.5.0-debian-11-r35
-    commonLabels:
-      backup: "true"
-      env: prod
-    primary:
-      persistence:
-        size: 5Gi
+# New chart (0.7.0) uses CloudPirates postgres subchart; see MIGRATION_PLAN.md.
+postgres:
+  enabled: true
+  commonLabels:
+    backup: "true"
+    env: prod
+  persistence:
+    enabled: true
+    size: 3Gi
+  customUser:
+    name: "webvh-admin"
+    database: "didwebvh-server"

--- a/services/didwebvh-server-py/charts/test/Chart.yaml
+++ b/services/didwebvh-server-py/charts/test/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.4.5
 appVersion: "0.4.5"
 dependencies:
   - name: didwebvh-server-py
-    version: 0.4.5
-    repository: https://identity.foundation/didwebvh-server-py
+    version: 0.7.0
+    repository: https://decentralized-identity.github.io/helm-charts

--- a/services/didwebvh-server-py/charts/test/values.yaml
+++ b/services/didwebvh-server-py/charts/test/values.yaml
@@ -1,71 +1,74 @@
 ---
-didwebvh-server-py:
+# Top-level keys so the DIF chart receives them (chart uses .Values.ingress, .Values.server, etc.)
+ingress:
+  annotations:
+    route.openshift.io/termination: edge
+  tls:
+    - secretName: webvh-server-tls
+      hosts:
+        - registry-test.digitaltrust.gov.bc.ca
+networkPolicy:
   ingress:
-    annotations:
-      route.openshift.io/termination: edge
-    tls:
-      - secretName: webvh-server-tls
-        hosts:
-          - registry-test.digitaltrust.gov.bc.ca
+    namespaceSelector:
+      network.openshift.io/policy-group: ingress
+
+server:
+  image:
+    repository: ghcr.io/decentralized-identity/didwebvh-server-py
+    tag: 0.5.0
+    pullPolicy: Always
+  host: "registry-test.digitaltrust.gov.bc.ca"
+  workers: "4"
+  policies:
+    webvh_version: "1.0"
+    webvh_witness: "true"
+    webvh_watcher: ""
+    webvh_prerotation: "false"
+    webvh_portability: "false"
+    webvh_endorsement: "true"
+    webvh_known_witness_key: ""
+    webvh_known_registry_url: ""
+
+  branding:
+    app_name: "BC Gov WebVH Test"
+    app_description: "BC Gov Test WebVH server deployment."
+    icon: "https://www2.gov.bc.ca/favicon.ico"
+    logo_vertical: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    logo_horizontal: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    app_primary_color: "#234075"
+    app_secondary_color: "#e3a82b"
+    app_accent_color: "#82B1FF"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    stabilizationWindowSeconds: 300
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
   networkPolicy:
+    enabled: true
     ingress:
+      enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
 
-  server:
-    image:
-      repository: ghcr.io/decentralized-identity/didwebvh-server-py
-      tag: 0.4.5
-      pullPolicy: Always
-    host: "registry-test.digitaltrust.gov.bc.ca"
-    workers: "4"
-    policies:
-      webvh_version: "1.0"
-      webvh_witness: "true"
-      webvh_watcher: ""
-      webvh_prerotation: "false"
-      webvh_portability: "false"
-      webvh_endorsement: "true"
-      webvh_known_witness_key: ""
-      webvh_known_registry_url: ""
-
-    branding:
-      app_name: "BC Gov WebVH Test"
-      app_description: "BC Gov Test WebVH server deployment."
-      app_icon: "https://www2.gov.bc.ca/favicon.ico"
-      app_logo: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
-      app_primary_color: "#234075"
-      app_secondary_color: "#e3a82b"
-      app_accent_color: "#82B1FF"
-
-    autoscaling:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
-      stabilizationWindowSeconds: 300
-    resources:
-      limits:
-        cpu: 250m
-        memory: 512Mi
-      requests:
-        cpu: 50m
-        memory: 128Mi
-    networkPolicy:
-      enabled: true
-      ingress:
-        enabled: true
-        namespaceSelector:
-          network.openshift.io/policy-group: ingress
-  postgresql:
-    image:
-      registry: artifacts.developer.gov.bc.ca
-      repository: docker-remote/bitnamilegacy/postgresql
-      tag: 14.5.0-debian-11-r35
-    commonLabels:
-      backup: "true"
-      env: test
-    primary:
-      persistence:
-        size: 5Gi
+# New chart (0.7.0) uses CloudPirates postgres subchart; see MIGRATION_PLAN.md.
+postgres:
+  enabled: true
+  commonLabels:
+    backup: "true"
+    env: test
+  persistence:
+    enabled: true
+    size: 3Gi
+  customUser:
+    name: "webvh-admin"
+    database: "didwebvh-server"

--- a/services/didwebvh-server-py/sandbox/values.yaml
+++ b/services/didwebvh-server-py/sandbox/values.yaml
@@ -32,12 +32,17 @@ server:
   branding:
     app_name: "BCVH Sandbox"
     app_description: "BC Gov community Sandbox WebVH server deployment."
-    app_icon: "https://www2.gov.bc.ca/favicon.ico"
-    app_logo: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    # Chart expects icon, logo_vertical, logo_horizontal (not app_icon/app_logo)
+    icon: "https://www2.gov.bc.ca/favicon.ico"
+    logo_vertical: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
+    logo_horizontal: "https://www2.gov.bc.ca/images/BCID_H_rgb_pos.png"
     app_primary_color: "#234075"
     app_secondary_color: "#e3a82b"
     app_accent_color: "#82B1FF"
-    
+
+  # Chart uses replicaCount (no HPA in DIF chart); set min replicas when autoscaling not used
+  replicaCount: 1
+
   autoscaling:
     enabled: true
     minReplicas: 1
@@ -58,14 +63,17 @@ server:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
-postgresql:
-  image:
-    registry: artifacts.developer.gov.bc.ca
-    repository: docker-remote/bitnamilegacy/postgresql
-    tag: 14.5.0-debian-11-r35
+
+# New chart (0.7.0) uses CloudPirates postgres subchart; see MIGRATION_PLAN.md for Bitnami → CloudPirates migration.
+postgres:
+  enabled: true
   commonLabels:
     backup: "false"
     env: sandbox
-  primary:
-    persistence:
-      size: 5Gi
+  persistence:
+    enabled: true
+    size: 5Gi
+  customUser:
+    name: "webvh-admin"
+    # Match app default so Postgres creates this DB (app expects "didwebvh-server" if POSTGRES_DB not set)
+    database: "didwebvh-server"


### PR DESCRIPTION
- Use DIF helm chart 0.7.0 (CloudPirates Postgres) for all four envs
- Values: top-level ingress, server, networkPolicy, postgres for each env
- sandbox/dev/test/prod: postgres.customUser.database=didwebvh-server, customUser.name=webvh-admin; env-specific hosts and branding
