### PR TITLE
feat: Update endorser acapy config for use with endorser service

### DIFF
--- a/services/endorser-service/aries/sandbox/values.yaml
+++ b/services/endorser-service/aries/sandbox/values.yaml
@@ -63,8 +63,8 @@ endorser-service:
       tag: "1.1.2"
 
     argfile.yml:
-      auto-accept-invites: true
-      auto-accept-requests: true
+      auto-accept-invites: false
+      auto-accept-requests: false
       debug-webhooks: true
       label: "Government of British Columbia - Sandbox Endorser"
       endorser-protocol-role: endorser
@@ -83,7 +83,6 @@ endorser-service:
       auto-ping-connection: true
       monitor-ping: true
       log-level: info
-      log-level: info
       plugin: []
 
     ledgers.yml:
@@ -92,8 +91,6 @@ endorser-service:
         is_write: true
         genesis_url: "http://test.bcovrin.vonx.io/genesis"
 
-    plugin-config.yml: null
-      # did-webvh: null
     plugin-config.yml: null
       # did-webvh: null
 


### PR DESCRIPTION
The endorser service controller handles auto accepting connections separately and expects the state to be in `request` state instead of bypassing this state straight into `active`.

This only applies to sandbox where we auto accept connections.

There was also a couple duplications in the acapy config.

Note: the `postgres` block is also duplicated in this chart. I didn't change it because I didn't want to make a mistake and cause a problem unrelated to what this PR is addressing. 