### PR TITLE
chore(traction): update sandbox WebVH witness_id

### DIFF
--- a/services/traction/sandbox/values.yaml
+++ b/services/traction/sandbox/values.yaml
@@ -52,7 +52,7 @@ acapy:
           auto_issuer: true
       webvh:
         server_url: https://sandbox.bcvh.vonx.io
-        witness_id: did:key:z6Mktqm2pXW48BZzSNnDzaA3yxo3zhfCUzAktVzFmzZHbVNn
+        witness_id: did:key:z6MkghLv3ccGvxDAuLfrhw3As2DvAb4Hn2JGwqHa5D5T88dJ
 
   secrets:
     api:


### PR DESCRIPTION
Updates `webvh.witness_id` in `services/traction/sandbox/values.yaml` to match the sandbox witness DID used in [bcgov/traction#1940](https://github.com/bcgov/traction/pull/1940) (`deploy/traction/values-pr.yaml` / `scripts/plugin-config.yml`).

Keeps Silver **traction sandbox** Helm values aligned with the BCVH witness rotation.

Made with [Cursor](https://cursor.com)