### PR TITLE
Set prod traction tennat ui buttons enabled

### DIFF
--- a/services/traction/charts/prod/values.yaml
+++ b/services/traction/charts/prod/values.yaml
@@ -114,7 +114,7 @@ traction:
     oidc:
       active: true
       showInnkeeperAdminLogin: true
-      showWritableComponents: false
+      showWritableComponents: true
       authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
       jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
       extraQueryParams: '{"kc_idp_hint":"idir"}'


### PR DESCRIPTION
Tracking change made to production env in OCP. Think that makes sense to commit now @esune ?

I'm not sure why this ended up nested under "odic" for the tenant UI setting (there's some others in there too), it's not related to auth. Can probably decide to reorg that at some point later. 