### PR TITLE
fix: update values for traction sandbox

### DIFF
--- a/services/traction/sandbox/values.yaml
+++ b/services/traction/sandbox/values.yaml
@@ -11,6 +11,7 @@ acapy:
   argfile.yml:
     tails-server-base-url: https://tails-dev.vonx.io
     tails-server-upload-url: https://tails-dev.vonx.io
+    wallet-type: askar-anoncreds
 
   ledgers.yml:
     - id: bcovrin-test
@@ -31,10 +32,6 @@ acapy:
       is_production: true
       is_write: false
       genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
-
-  multitenancyConfiguration:
-    json: ""
-    wallet_type: single-wallet-askar
 
   plugin-config.yml:
       traction_innkeeper:
@@ -75,17 +72,6 @@ acapy:
       hostname: '{{- printf "%s-admin%s" (include "common.names.fullname" .) .Values.global.ingressSuffix }}'
       annotations:
         route.openshift.io/termination: edge
-  
-  extraArgs:
-    - --plugin 'aries_cloudagent.messaging.jsonld'
-    - --plugin traction_plugins.traction_innkeeper.v1_0
-    - --plugin multitenant_provider.v1_0
-    - --plugin basicmessage_storage.v1_0
-    - --plugin connections
-    - --plugin connection_update.v1_0
-    - --plugin rpc.v1_0
-    - --plugin webvh
-  
   
   autoscaling:
     enabled: true


### PR DESCRIPTION
Changing values to align with latest Traction chart and use `askar-anoncreds` as default wallet next time sandbox resets.