### PR TITLE
VCAuthN: SSE Reconnect handling (match VCAuth default template page)

### DIFF
--- a/services/vc-authn-oidc/templates/verified_credentials.html
+++ b/services/vc-authn-oidc/templates/verified_credentials.html
@@ -375,38 +375,63 @@
         },
       },
       mounted() {
-        /**
-         * Initialize SSE connection for real-time status updates.
-         * EventSource auto-reconnects natively on disconnect.
-         */
-        this._evtSource = new EventSource('/sse/status/{{pid}}');
-        this._evtSource.addEventListener('status', (e) => {
-          let status;
-          try {
-            const data = JSON.parse(e.data);
-            if (!data || typeof data.status !== 'string') {
-              console.warn("SSE status event has unexpected payload:", e.data);
+        // Wrap EventSource setup so we can re-open on visibilitychange. When the
+        // user returns from a wallet deep-link, force a reconnect if the
+        // connection is no longer OPEN — the server re-reads DB state on every
+        // connect, so this picks up any terminal status that fired while the
+        // tab was backgrounded. A healthy OPEN connection is left alone to
+        // avoid churn on brief tab switches.
+        const vm = this;
+        const terminalStatuses = ['verified', 'failed', 'expired', 'abandoned'];
+        let evtSource = null;
+
+        const connect = () => {
+          if (evtSource) evtSource.close();
+          evtSource = new EventSource('/sse/status/{{pid}}');
+          evtSource.addEventListener('status', (e) => {
+            let status;
+            try {
+              const data = JSON.parse(e.data);
+              if (!data || typeof data.status !== 'string') {
+                console.warn("SSE status event has unexpected payload:", e.data);
+                return;
+              }
+              status = data.status;
+            } catch (err) {
+              console.warn("Failed to parse SSE status event payload:", e.data, err);
               return;
             }
-            status = data.status;
-          } catch (err) {
-            console.warn("Failed to parse SSE status event payload:", e.data, err);
-            return;
-          }
-          console.log("SSE status update:", status);
-          this.setUiStates(status);
-          if (['verified', 'failed', 'expired', 'abandoned'].includes(status)) {
-            this._evtSource.close();
-          }
-        });
-        this._evtSource.onerror = (e) => {
-          console.error("SSE connection error, will auto-reconnect:", e);
+            console.log("SSE status update:", status);
+            vm.setUiStates(status);
+            if (terminalStatuses.includes(status)) {
+              evtSource.close();
+              evtSource = null;
+            }
+          });
+          evtSource.onerror = (e) => {
+            console.error("SSE connection error, will auto-reconnect:", e);
+          };
         };
+
+        const onVisibilityChange = () => {
+          if (
+            document.visibilityState === 'visible' &&
+            evtSource !== null &&
+            evtSource.readyState !== EventSource.OPEN
+          ) {
+            connect();
+          }
+        };
+
+        connect();
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        this._sseVisibilityHandler = onVisibilityChange;
+        this._sseGetEvtSource = () => evtSource;
       },
       beforeUnmount() {
-        if (this._evtSource) {
-          this._evtSource.close();
-        }
+        document.removeEventListener('visibilitychange', this._sseVisibilityHandler);
+        const evtSource = this._sseGetEvtSource && this._sseGetEvtSource();
+        if (evtSource) evtSource.close();
       },
       delimiters: ["[[", "]]"],
     });


### PR DESCRIPTION
Equivalent change from: https://github.com/openwallet-foundation/acapy-vc-authn-oidc/pull/1044
(can see that PR/ticket for details)