### PR TITLE
Traction sandbox action: Pass to next step on uninstall failure (uses `all`)

### DIFF
--- a/.github/workflows/uninstall_install_sandbox.yaml
+++ b/.github/workflows/uninstall_install_sandbox.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Remove Traction Openshift Objects
         run: |
-          oc delete -n ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }} all,secret,pod,networkpolicy,configmap,pvc --selector "app.kubernetes.io/instance"=traction-sandbox
+          oc delete -n ${{ secrets.OPENSHIFT_NAMESPACE_SANDBOX }} all,secret,pod,networkpolicy,configmap,pvc --selector "app.kubernetes.io/instance"=traction-sandbox || true
 
       # - name: Uninstall DID WebVH Server via Helm
       #   run: |


### PR DESCRIPTION
Traction Sandbox uninstall failed on a permission error, see https://github.com/bcgov/DITP-DevOps/issues/356 for issue.

Seems that the cleanup step running `oc delete ... all,secret,pod,... ` as usual successfully deleted all the actual Traction sandbox resources (pods, secrets, PVCs), but then hit a permissions error on an unrelated cluster resource type (`applications.app.k8s.io`, a CRD introduced by a Red Hat OpenShift AI/Open Data Hub operator installed cluster-wide around that time) that got swept in by the `all`. That Forbidden error makes the whole step, and therefore the whole job, exit as failed, even though the actual cleanup work was already done.

Adjust `oc delete` command with a `|| true` the same way the helm uninstall above it has. It's going to successfully delete sandbox-selector things anyways (or there's a bigger issue) so pass along if there's some issue listing a resource we don't care about in this job.
